### PR TITLE
Update README to remove Heroku hosting details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Discord Bot V2
 Upgraded version of my original discord bot using Discord.JS V14 and Firebase Firestore.
-Currently hosting my bot through Heroku for personal/friend use.
 
 Now also includes basic integration of an LLM model from OpenRouter. Just mention the bot to talk to it.


### PR DESCRIPTION
Removed hosting information for the Discord bot.